### PR TITLE
feat(host-base): add `xorriso` for kickstart

### DIFF
--- a/host-base/Dockerfile
+++ b/host-base/Dockerfile
@@ -18,7 +18,8 @@ RUN apk add \
 	kmod \
 	pciutils \
 	util-linux \
-	tzdata
+	tzdata \
+	xorriso
 
 RUN find /var/cache/ -type f | xargs rm -vf
 

--- a/host-base/Makefile
+++ b/host-base/Makefile
@@ -1,4 +1,4 @@
-tag:=v0.7.0
+tag:=v0.8.0
 
 REPO?=registry.cn-beijing.aliyuncs.com/yunionio/host-base
 


### PR DESCRIPTION
Add xorriso package to provide mkisofs  for kickstart automated installations. The mkisofs tool is required to package configuration files into ISO images during the automated installation process.

related PR https://github.com/yunionio/cloudpods/pull/23094